### PR TITLE
fix buffer overflow in GetSizeForDevID

### DIFF
--- a/edid-checker/edid.cpp
+++ b/edid-checker/edid.cpp
@@ -124,7 +124,7 @@ bool GetSizeForDevID( const CString &TargetDevID, short &WidthMm, short &HeightM
         if( SetupDiEnumDeviceInfo( devInfo, i, &devInfoData ) ) {
         
             TCHAR Instance[MAX_DEVICE_ID_LEN];
-            SetupDiGetDeviceInstanceId( devInfo, &devInfoData, Instance, MAX_PATH, NULL );
+            SetupDiGetDeviceInstanceId( devInfo, &devInfoData, Instance, MAX_DEVICE_ID_LEN, NULL );
             
             CString sInstance( Instance );
             


### PR DESCRIPTION
MAX_DEVICE_ID_LEN is defined as 200
MAX_PATH is defined as 260

in the codes current state SetupDiGetDeviceInstanceId can potentially
read 260 (MAX_PATH) chars into the Instance buffer which only has room
for 200 (MAX_DEVICE_ID_LEN) chars